### PR TITLE
[CURA-11035] Plugins specify a verion-range, slots just a version.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -63,7 +63,7 @@ class CuraEngineInfillGeneratePluginConan(ConanFile):
         cmake_layout(self)
 
     def requirements(self):
-        self.requires("curaengine_grpc_definitions/latest@ultimaker/cura_10446")
+        self.requires("curaengine_grpc_definitions/latest@ultimaker/cura_11035")  # FIXME!: Can be set to .../testing after merge?
         self.requires("asio-grpc/2.6.0")
         self.requires("boost/1.82.0")
         self.requires("spdlog/1.11.0")

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
@@ -63,7 +62,7 @@ class CuraEngineInfillGeneratePluginConan(ConanFile):
         cmake_layout(self)
 
     def requirements(self):
-        self.requires("curaengine_grpc_definitions/latest@ultimaker/cura_11035")  # FIXME!: Can be set to .../testing after merge?
+        self.requires("curaengine_grpc_definitions/latest@ultimaker/testing")
         self.requires("asio-grpc/2.6.0")
         self.requires("boost/1.82.0")
         self.requires("spdlog/1.11.0")

--- a/include/plugin/handshake.h
+++ b/include/plugin/handshake.h
@@ -40,7 +40,7 @@ struct Handshake
                 boost::asio::use_awaitable);
 
             spdlog::info("Received handshake request");
-            spdlog::info("Slot ID: {}, slot version range: {}, plugin name: {}, plugin version: {}", static_cast<int>(request.slot_id()), request.version_range(), request.plugin_name(), request.plugin_version());
+            spdlog::info("Slot ID: {}, slot version: {}, plugin name: {}, plugin version: {}", static_cast<int>(request.slot_id()), request.version(), request.plugin_name(), request.plugin_version());
 
             const bool exists = Settings::validatePlugin(request, metadata);
             if (!exists)
@@ -52,7 +52,7 @@ struct Handshake
 
             cura::plugins::slots::handshake::v0::CallResponse response;
             response.set_plugin_name(static_cast<std::string>(metadata->plugin_name));
-            response.set_slot_version(static_cast<std::string>(metadata->slot_version));
+            response.set_slot_version_range(static_cast<std::string>(metadata->slot_version_range));
             response.set_plugin_version(static_cast<std::string>(metadata->plugin_version));
             for (auto slot_id : broadcast_subscriptions)
             {

--- a/include/plugin/metadata.h
+++ b/include/plugin/metadata.h
@@ -13,7 +13,7 @@ namespace plugin
 
 struct Metadata
 {
-    std::string_view slot_version{ "0.1.0-alpha" };
+    std::string_view slot_version_range{ ">=0.1.0" };
     std::string_view plugin_name{ cmdline::NAME };
     std::string_view plugin_version{ cmdline::VERSION };
 };


### PR DESCRIPTION
This plugin doesn't work with the current system for now, will fix that later. Until then, this is a draft PR. (If you find this PR later, and the plugin works, it's most likely safe to delete this.)

Not the other way around as we have now. This also adheres closer to the way we handle front-end plugins. Ideally you'd maybe want both of them to be ranges, but that's for the future.